### PR TITLE
Add Google Calendar integration

### DIFF
--- a/backend/app/alembic/versions/847d7a4df0ea_add_google_credentials.py
+++ b/backend/app/alembic/versions/847d7a4df0ea_add_google_credentials.py
@@ -1,0 +1,33 @@
+"""Add Google credentials table
+
+Revision ID: 847d7a4df0ea
+Revises: 1a31ce608336
+Create Date: 2024-08-22 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+# revision identifiers, used by Alembic.
+revision = '847d7a4df0ea'
+down_revision = '1a31ce608336'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'googlecredentials',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('credentials_json', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('expiry', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('googlecredentials')

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.routes import items, login, private, users, utils
+from app.api.routes import google, items, login, private, users, utils
 from app.core.config import settings
 
 api_router = APIRouter()
@@ -8,6 +8,7 @@ api_router.include_router(login.router)
 api_router.include_router(users.router)
 api_router.include_router(utils.router)
 api_router.include_router(items.router)
+api_router.include_router(google.router)
 
 
 if settings.ENVIRONMENT == "local":

--- a/backend/app/api/routes/google.py
+++ b/backend/app/api/routes/google.py
@@ -1,0 +1,48 @@
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from app import crud
+from app.api.deps import CurrentUser, SessionDep
+from app.models import Message
+
+router = APIRouter(prefix="/google", tags=["google"])
+
+
+@router.post("/credentials", response_model=Message)
+def save_credentials(
+    *, session: SessionDep, current_user: CurrentUser, credentials_json: str
+) -> Message:
+    """Save Google OAuth credentials for the current user."""
+    crud.upsert_google_credentials(session, current_user.id, credentials_json)
+    return Message(message="Credentials saved")
+
+
+@router.get("/events/next-hour")
+def get_events_next_hour(session: SessionDep, current_user: CurrentUser) -> Any:
+    """Get Google Calendar events for the next hour."""
+    creds = crud.get_google_credentials(session, current_user.id)
+    if not creds:
+        raise HTTPException(status_code=404, detail="Google credentials not found")
+    data = json.loads(creds.credentials_json)
+    credentials = Credentials.from_authorized_user_info(data)
+    service = build("calendar", "v3", credentials=credentials)
+    now = datetime.now(timezone.utc)
+    time_min = now.isoformat()
+    time_max = (now + timedelta(hours=1)).isoformat()
+    events_result = (
+        service.events()
+        .list(
+            calendarId="primary",
+            timeMin=time_min,
+            timeMax=time_max,
+            singleEvents=True,
+            orderBy="startTime",
+        )
+        .execute()
+    )
+    return {"events": events_result.get("items", [])}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import uuid
+from datetime import datetime
 
 from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
@@ -43,7 +46,8 @@ class UpdatePassword(SQLModel):
 class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str
-    items: list["Item"] = Relationship(back_populates="owner", cascade_delete=True)
+    items: list[Item] = Relationship(back_populates="owner", cascade_delete=True)
+    google_credentials: GoogleCredentials | None = Relationship(back_populates="user")
 
 
 # Properties to return via API, id is always required
@@ -111,3 +115,14 @@ class TokenPayload(SQLModel):
 class NewPassword(SQLModel):
     token: str
     new_password: str = Field(min_length=8, max_length=40)
+
+
+class GoogleCredentials(SQLModel, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(
+        foreign_key="user.id", unique=True, nullable=False, ondelete="CASCADE"
+    )
+    credentials_json: str
+    expiry: datetime | None = None
+
+    user: User | None = Relationship(back_populates="google_credentials")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pydantic-settings<3.0.0,>=2.2.1",
     "sentry-sdk[fastapi]<2.0.0,>=1.40.6",
     "pyjwt<3.0.0,>=2.8.0",
+    "google-api-python-client<3.0.0,>=2.120.0",
+    "google-auth<3.0.0,>=2.29.0",
+    "google-auth-oauthlib<2.0.0,>=1.1.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- add dependencies for Google API integration
- support storing Google OAuth credentials
- create API routes for saving credentials and fetching events
- expose Google routes in the main API router
- include Alembic migration for new model

## Testing
- `pre-commit run --files backend/app/models.py backend/app/api/routes/google.py backend/app/api/main.py backend/app/crud.py backend/pyproject.toml backend/app/alembic/versions/847d7a4df0ea_add_google_credentials.py`
- `bash backend/scripts/test.sh` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f4318ef7483318672d0bef7c368a5