### PR TITLE
Add basic Google Calendar UI

### DIFF
--- a/frontend/src/client/GoogleService.ts
+++ b/frontend/src/client/GoogleService.ts
@@ -1,0 +1,26 @@
+import type { CancelablePromise } from "./core/CancelablePromise"
+import { OpenAPI } from "./core/OpenAPI"
+import { request as __request } from "./core/request"
+import type { Message } from "./types.gen"
+
+export class GoogleService {
+  /** Save Google OAuth credentials */
+  public static saveCredentials(
+    credentials_json: string,
+  ): CancelablePromise<Message> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/google/credentials",
+      body: credentials_json,
+      mediaType: "application/json",
+    })
+  }
+
+  /** Get Google Calendar events for the next hour */
+  public static getEventsNextHour(): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/google/events/next-hour",
+    })
+  }
+}

--- a/frontend/src/components/Common/SidebarItems.tsx
+++ b/frontend/src/components/Common/SidebarItems.tsx
@@ -1,7 +1,13 @@
 import { Box, Flex, Icon, Text } from "@chakra-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link as RouterLink } from "@tanstack/react-router"
-import { FiBriefcase, FiHome, FiSettings, FiUsers } from "react-icons/fi"
+import {
+  FiBriefcase,
+  FiCalendar,
+  FiHome,
+  FiSettings,
+  FiUsers,
+} from "react-icons/fi"
 import type { IconType } from "react-icons/lib"
 
 import type { UserPublic } from "@/client"
@@ -9,6 +15,7 @@ import type { UserPublic } from "@/client"
 const items = [
   { icon: FiHome, title: "Dashboard", path: "/" },
   { icon: FiBriefcase, title: "Items", path: "/items" },
+  { icon: FiCalendar, title: "Calendar", path: "/calendar" },
   { icon: FiSettings, title: "User Settings", path: "/settings" },
 ]
 

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as LayoutImport } from './routes/_layout'
 import { Route as LayoutIndexImport } from './routes/_layout/index'
 import { Route as LayoutSettingsImport } from './routes/_layout/settings'
 import { Route as LayoutItemsImport } from './routes/_layout/items'
+import { Route as LayoutCalendarImport } from './routes/_layout/calendar'
 import { Route as LayoutAdminImport } from './routes/_layout/admin'
 
 // Create/Update Routes
@@ -63,6 +64,11 @@ const LayoutItemsRoute = LayoutItemsImport.update({
   getParentRoute: () => LayoutRoute,
 } as any)
 
+const LayoutCalendarRoute = LayoutCalendarImport.update({
+  path: '/calendar',
+  getParentRoute: () => LayoutRoute,
+} as any)
+
 const LayoutAdminRoute = LayoutAdminImport.update({
   path: '/admin',
   getParentRoute: () => LayoutRoute,
@@ -96,6 +102,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAdminImport
       parentRoute: typeof LayoutImport
     }
+    '/_layout/calendar': {
+      preLoaderRoute: typeof LayoutCalendarImport
+      parentRoute: typeof LayoutImport
+    }
     '/_layout/items': {
       preLoaderRoute: typeof LayoutItemsImport
       parentRoute: typeof LayoutImport
@@ -116,6 +126,7 @@ declare module '@tanstack/react-router' {
 export const routeTree = rootRoute.addChildren([
   LayoutRoute.addChildren([
     LayoutAdminRoute,
+    LayoutCalendarRoute,
     LayoutItemsRoute,
     LayoutSettingsRoute,
     LayoutIndexRoute,

--- a/frontend/src/routes/_layout/calendar.tsx
+++ b/frontend/src/routes/_layout/calendar.tsx
@@ -1,0 +1,73 @@
+import {
+  Box,
+  Button,
+  Container,
+  Heading,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react"
+import { useMutation } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
+import type { ApiError } from "@/client"
+import { GoogleService } from "@/client/GoogleService"
+import { Field } from "@/components/ui/field"
+import useCustomToast from "@/hooks/useCustomToast"
+import { handleError } from "@/utils"
+
+export const Route = createFileRoute("/_layout/calendar")({
+  component: CalendarPage,
+})
+
+function CalendarPage() {
+  const [credentials, setCredentials] = useState("")
+  const { showSuccessToast } = useCustomToast()
+  const saveMutation = useMutation({
+    mutationFn: GoogleService.saveCredentials,
+    onSuccess: () => {
+      showSuccessToast("Credentials saved")
+    },
+    onError: (err: ApiError) => handleError(err),
+  })
+  const eventsMutation = useMutation({
+    mutationFn: GoogleService.getEventsNextHour,
+    onError: (err: ApiError) => handleError(err),
+  })
+
+  return (
+    <Container maxW="full">
+      <Heading size="lg" pt={12} mb={4}>
+        Google Calendar
+      </Heading>
+      <VStack align="stretch" gap={4} maxW="lg">
+        <Field label="Credentials JSON">
+          <Textarea
+            value={credentials}
+            onChange={(e) => setCredentials(e.target.value)}
+            rows={6}
+          />
+        </Field>
+        <Button
+          onClick={() => saveMutation.mutate(credentials)}
+          loading={saveMutation.isPending}
+        >
+          Save Credentials
+        </Button>
+        <Button
+          onClick={() => eventsMutation.mutate()}
+          loading={eventsMutation.isPending}
+        >
+          Load Events (Next Hour)
+        </Button>
+        {eventsMutation.data && (
+          <Box as="pre" whiteSpace="pre-wrap">
+            {JSON.stringify(eventsMutation.data, null, 2)}
+          </Box>
+        )}
+      </VStack>
+    </Container>
+  )
+}
+
+export default CalendarPage


### PR DESCRIPTION
## Summary
- add GoogleService client wrapper
- add Calendar page and link in sidebar
- update route tree

## Testing
- `npm run lint`
- `npm run build`
- `bash backend/scripts/test.sh` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_683f4921b2448331b5f54cafca486f03